### PR TITLE
change goal format to block-gripper-informed goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 build
 dist
 pretrained
+*.egg-info

--- a/agent/DDPG.py
+++ b/agent/DDPG.py
@@ -90,7 +90,7 @@ class DDPG:
 
             # Compute critic loss
             critic_loss = self.mseLoss(self.critic(state, action, goal), target_Q)
-            self.writer.add_scalar('critic_loss', critic_loss, timestep)
+            self.writer.add_scalar("critic_loss", critic_loss, timestep)
             # Optimize Critic:
             self.critic_optimizer.zero_grad()
             critic_loss.backward()
@@ -98,7 +98,7 @@ class DDPG:
 
             # Compute actor loss:
             actor_loss = -self.critic(state, self.actor(state, goal), goal).mean()
-            self.writer.add_scalar('actor_loss', actor_loss, timestep)
+            self.writer.add_scalar("actor_loss", actor_loss, timestep)
             # Optimize the actor
             self.actor_optimizer.zero_grad()
             actor_loss.backward()

--- a/agent/DDPG.py
+++ b/agent/DDPG.py
@@ -48,7 +48,8 @@ class Critic(nn.Module):
 
 
 class DDPG:
-    def __init__(self, state_dim, goal_dim, action_dim, action_bounds, offset, lr, H):
+    def __init__(self, state_dim, goal_dim, action_dim, action_bounds, offset, lr, H, name=""):
+        self.name = name
 
         self.actor = Actor(state_dim, goal_dim, action_dim, action_bounds, offset).to(device)
         self.actor_optimizer = optim.Adam(self.actor.parameters(), lr=lr)
@@ -90,7 +91,7 @@ class DDPG:
 
             # Compute critic loss
             critic_loss = self.mseLoss(self.critic(state, action, goal), target_Q)
-            self.writer.add_scalar("critic_loss", critic_loss, timestep)
+            self.writer.add_scalar(f"{self.name}/critic_loss", critic_loss, timestep)
             # Optimize Critic:
             self.critic_optimizer.zero_grad()
             critic_loss.backward()
@@ -98,7 +99,7 @@ class DDPG:
 
             # Compute actor loss:
             actor_loss = -self.critic(state, self.actor(state, goal), goal).mean()
-            self.writer.add_scalar("actor_loss", actor_loss, timestep)
+            self.writer.add_scalar(f"{self.name}/actor_loss", actor_loss, timestep)
             # Optimize the actor
             self.actor_optimizer.zero_grad()
             actor_loss.backward()

--- a/agent/HAC.py
+++ b/agent/HAC.py
@@ -161,7 +161,7 @@ class HAC:
                     else:
                         action = np.random.uniform(self.goal_clip_low, self.goal_clip_high)
 
-                    if abs(action[4] - action[-1]) < 0.02:
+                    if distance(action[4:7], action[7:]) < 0.02:
                         action[-1] *= 3  # if blocks are ovelapped stack-up
 
                 # Determine whether to test subgoal (action)

--- a/agent/HAC.py
+++ b/agent/HAC.py
@@ -205,7 +205,7 @@ class HAC:
                     else:
                         action = np.random.uniform(self.goal_clip_low, self.goal_clip_high)
 
-                    if distance(action[4:7], action[7:]) < 0.02:
+                    if distance(action[4:7], action[7:]) < 0.02:# object size/2
                         action[-1] *= 3  # if blocks are ovelapped stack-up
 
                 # Determine whether to test subgoal (action)
@@ -255,6 +255,7 @@ class HAC:
                 # this is for logging
                 self.reward += rew
                 self.timestep += 1
+                self.writer.add_scalar('reward', self.reward, self.timestep)
 
             #   <================ finish one step/transition ================>
             # check if goal is achieved

--- a/agent/HAC.py
+++ b/agent/HAC.py
@@ -14,6 +14,7 @@ class HAC:
         # init
         self.render = render
         self.env = env
+        self.writer = None
 
         self.set_parameters(config["Parameter"])
 
@@ -74,6 +75,13 @@ class HAC:
         # exploration noise
         self.exploration_action_noise = np.array([float(config["exploration_action_noise"])] * self.action_dim)
         self.exploration_goal_noise = np.array([float(config["exploration_goal_noise"])] * self.goal_dim)
+    
+    def set_tensorboard_writer(self, writer):
+        self.writer = writer
+
+        # set writers in agents
+        for i_level in range(self.k_level):
+            self.HAC[i_level].set_tensorboard_writer(self.writer)
 
     def render_subgoal(self, subgoal):
         p = self.env.sim.physics_client
@@ -85,7 +93,7 @@ class HAC:
         if not self.subgoal_2 is None:
             p.removeBody(self.subgoal_2)
 
-        # visualize ee position
+        # visualize ee position(subgoal)
         sphere_0 = p.createVisualShape(
             shapeType=p.GEOM_SPHERE,
             radius=0.02,
@@ -241,10 +249,10 @@ class HAC:
 
     def train(self, max_episodes, save_episode, save_path=("", "")):
 
+        self.timestep = 0
         # training procedure
         for i_episode in range(1, max_episodes + 1):
             self.reward = 0
-            self.timestep = 0
 
             state = self.env.reset()
             # collecting experience in environment
@@ -261,7 +269,7 @@ class HAC:
     def update(self, n_iter, batch_size):
         for i in range(self.k_level):
             print(f"level: {i} Update!")
-            self.HAC[i].update(self.replay_buffer[i], n_iter, batch_size)
+            self.HAC[i].update(self.replay_buffer[i], n_iter, batch_size, self.timestep)
 
     def save(self, save_path):
         directory, name = save_path

--- a/agent/HAC.py
+++ b/agent/HAC.py
@@ -75,7 +75,7 @@ class HAC:
         # exploration noise
         self.exploration_action_noise = np.array([float(config["exploration_action_noise"])] * self.action_dim)
         self.exploration_goal_noise = np.array([float(config["exploration_goal_noise"])] * self.goal_dim)
-    
+
     def set_tensorboard_writer(self, writer):
         self.writer = writer
 

--- a/agent/config/multi_step_agent.cfg
+++ b/agent/config/multi_step_agent.cfg
@@ -11,7 +11,8 @@ exploration_action_noise = 0.05
 gamma = 0.95
 n_iter = 100
 batch_size = 256
-lr = 0.001
+lr = 0.003
+tau = 0.05
 
 # Environment
 threshold = 0.1

--- a/agent/config/multi_step_agent.cfg
+++ b/agent/config/multi_step_agent.cfg
@@ -16,5 +16,6 @@ lr = 0.001
 # Environment
 threshold = 0.1
 
-workspace_low = [-0.15, -0.15, 0]
-workspace_high = [0.15, 0.15, 0.3]
+# Difine Subgoal Space
+goal_clip_low=[-0.15, -0.15, 0, -0.04, -0.15, -0.15, 0.02, -0.15, -0.15, 0.02]
+goal_clip_high=[0.15, 0.15, 0.3, 0.04, 0.15, 0.15, 0.02, 0.15, 0.15, 0.02]

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -26,9 +26,7 @@ class ReplayBuffer:
             self.size = len(self.buffer)
 
         indexes = np.random.randint(0, len(self.buffer), size=batch_size)
-        states, actions, rewards, next_states, goals, gamma, dones = (
-            [] for _ in range(7)
-        )
+        states, actions, rewards, next_states, goals, gamma, dones = ([] for _ in range(7))
 
         for i in indexes:
             states.append(np.array(self.buffer[i][0], copy=False))

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -26,7 +26,15 @@ class ReplayBuffer:
             self.size = len(self.buffer)
 
         indexes = np.random.randint(0, len(self.buffer), size=batch_size)
-        states, actions, rewards, next_states, goals, gamma, dones = [], [], [], [], [], [], []
+        states, actions, rewards, next_states, goals, gamma, dones = (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
 
         for i in indexes:
             states.append(np.array(self.buffer[i][0], copy=False))

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -27,13 +27,7 @@ class ReplayBuffer:
 
         indexes = np.random.randint(0, len(self.buffer), size=batch_size)
         states, actions, rewards, next_states, goals, gamma, dones = (
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
+            [] for _ in range(7)
         )
 
         for i in indexes:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,3 +29,9 @@ python multi_step_train.py --env-id PandaReach-v1
 #  --env-id ENV_ID  panda-gym environment[PandaReach-v1, PandaSlice-v1, PandaPush-v1, PandaPickAndPlace-v1, PandaStack-v1]
 
 ```
+
+### Supporting TensorBoard
+```bash
+tensorboard --logdir=$(LOGDIR)
+# e.g. `tensorboard --logdir=pretrained/PandaStack-v1/logs/`
+```

--- a/scripts/multi_step_train.py
+++ b/scripts/multi_step_train.py
@@ -22,7 +22,7 @@ def visualize_workspace(env: Env, config: configparser.ConfigParser) -> None:
         config(ConfigParser): parsed data(parameters) from configuration file
     """
     config = config["Parameter"]
-    workspace_high = literal_eval(config["workspace_high"])
+    workspace_high = literal_eval(config["goal_clip_high"])
 
     env.sim.create_box(
         body_name="workspace",

--- a/scripts/multi_step_train.py
+++ b/scripts/multi_step_train.py
@@ -8,8 +8,8 @@ import numpy as np
 import panda_gym
 import torch
 from gym.core import Env
-
 from torch.utils.tensorboard import SummaryWriter
+
 from agent import HAC as trainer
 
 
@@ -70,7 +70,6 @@ def main(args: argparse.ArgumentParser, config: configparser.ConfigParser) -> No
 
     # Visualize workspace
     visualize_workspace(env, config)
-
 
     # Initialize HAC agent and setting parameters
     agent = trainer.HAC(env, config, render=False if args.no_render else True)

--- a/scripts/multi_step_train.py
+++ b/scripts/multi_step_train.py
@@ -9,6 +9,7 @@ import panda_gym
 import torch
 from gym.core import Env
 
+from torch.utils.tensorboard import SummaryWriter
 from agent import HAC as trainer
 
 
@@ -70,6 +71,7 @@ def main(args: argparse.ArgumentParser, config: configparser.ConfigParser) -> No
     # Visualize workspace
     visualize_workspace(env, config)
 
+
     # Initialize HAC agent and setting parameters
     agent = trainer.HAC(env, config, render=False if args.no_render else True)
 
@@ -80,6 +82,10 @@ def main(args: argparse.ArgumentParser, config: configparser.ConfigParser) -> No
     if not os.path.exists(directory):
         os.makedirs(directory)
     save_path = (directory, filename)
+
+    # tensorboard writer
+    writer = SummaryWriter(f"{path}/pretrained/{args.env_id}/logs")
+    agent.set_tensorboard_writer(writer)
 
     # train
     agent.train(max_episodes=1000, save_episode=10, save_path=save_path)

--- a/scripts/multi_step_train.py
+++ b/scripts/multi_step_train.py
@@ -87,7 +87,7 @@ def main(args: argparse.ArgumentParser, config: configparser.ConfigParser) -> No
     agent.set_tensorboard_writer(writer)
 
     # train
-    agent.train(max_episodes=1000, save_episode=10, save_path=save_path)
+    agent.train(max_episodes=5000, save_episode=10, save_path=save_path)
 
 
 if __name__ == "__main__":

--- a/scripts/single_step_train.py
+++ b/scripts/single_step_train.py
@@ -69,7 +69,12 @@ def main(args):
     env = Monitor(env, log_dir)
     callback = SaveOnBestTrainingRewardCallback(check_freq=100, log_dir=log_dir)  # check frequency set for reward checking
 
-    her_kwargs = dict(online_sampling=True, n_sampled_goal=4, goal_selection_strategy="future", max_episode_length=100)
+    her_kwargs = dict(
+        online_sampling=True,
+        n_sampled_goal=4,
+        goal_selection_strategy="future",
+        max_episode_length=100,
+    )
 
     # Add our Landmark
     p = env.sim.physics_client


### PR DESCRIPTION
## Description
![Peek 2021-10-20 00-01](https://user-images.githubusercontent.com/26274945/137937579-2b8b685c-f68f-40c8-a4a3-d0824a873969.gif)

### Feature
1. changed goal format to block-gripper-informed.
  - final_goal -> block-informed
  - sub_goal -> block-gripper-informed
  - (that's why codes are messed up now. need to clean the codes later.)
2. visualize subgoals
  - obvious boxes(red one and green one) -> now states of objects
  - ghost boxes(red one and green one) -> targets of objects
  - ghost spheres
    - red one and green one -> subgoals of objects
    - black one -> subgoals of ee position

## Checklist

- [x] this code is auto-formatted using `make format`
- [x] I updated the READMEs and the documentation, if necessary.